### PR TITLE
Allow optional character `=` in domain syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,46 @@
-# php-whois
+# php-whois2
 
-PHP class to retrieve WHOIS information.
+Fork of php-whois, a PHP class to retrieve WHOIS information. You can view the original codebase here: https://github.com/regru/php-whois
+
+## Differences with php-whois
+
+**TL;DR this allows lookups with `=domain` syntax.**
+
+WHOIS allows lookups in the form of `=domain` to single out domains registered with different registrars (e.g. `gmail.com`) and return its full lookup info.
+
+Otherwise, simply looking up with `domain` (without the `=`) for certain domains will yield a notice from WHOIS to specify the search. For example, in looking up `gmail.com`, we get the following response:
+
+```
+Whois Server Version 2.0
+
+Domain names in the .com and .net domains can now be registered
+with many different competing registrars. Go to http://www.internic.net
+for detailed information.
+
+GMAIL.COM.BR
+GMAIL.COM.DEADKNIFERECORDS.COM
+GMAIL.COM.MY
+GMAIL.COM.TEJAARH.COM
+GMAIL.COM
+
+To single out one record, look it up with &quot;xxx&quot;, where xxx is one of the
+records displayed above. If the records are the same, look them up
+with &quot;=xxx&quot; to receive a full display for each record.
+
+...
+```
+
+Specifying with `=` yields the info we need:
+
+```
+string(3620) "Domain Name: gmail.com
+Registry Domain ID: 4667231_DOMAIN_COM-VRSN
+Registrar WHOIS Server: whois.markmonitor.com
+...
+```
+
+Due to the very immediate need for this, I have decided to create a fork and update from there. This should no longer be a problem once the PR for this is accepted and merged. You can view the PR here: https://github.com/regru/php-whois/pull/64
+
 
 ## Example of usage
 
@@ -8,18 +48,7 @@ PHP class to retrieve WHOIS information.
 
 <?php
 
-$sld = 'reg.ru';
-
-$domain = new Phois\Whois\Whois($sld);
-
-$whois_answer = $domain->info();
-
-echo $whois_answer;
-
-if ($domain->isAvailable()) {
-    echo "Domain is available\n";
-} else {
-    echo "Domain is registered\n";
-}
-
+$domain = new Phois\Whois\Whois('=gmail.com');
+$domainInfo = $domain->info();
+echo domainInfo;
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-    "name": "phois/whois",
-    "description": "Whois client.",
-    "keywords": ["whois"],
-    "version": "1.0.0",
+    "name": "php-whois/whois",
+    "description": "Whois client for PHP, forked from phois/whois (credits to the original developers). This one allows `=domain` syntax for specifying domain queries when interacting with the whois API." ,
+    "keywords": ["whois", "phois", "php"],
+    "version": "1.0.1",
     "license": "MIT",
     "authors": [
         {
@@ -10,6 +10,10 @@
             "email": "David.R.Rivera193@gmail.com",
             "homepage": "http://www.protodx.com",
             "role": "Systems Developer"
+        },
+        {
+            "name": "Mireya Andres",
+            "email": "mireyagenandres@gmail.com"
         }
     ],
     "require": {

--- a/src/Phois/Whois/Whois.php
+++ b/src/Phois/Whois/Whois.php
@@ -20,8 +20,8 @@ class Whois
         $this->domain = $domain;
         // check $domain syntax and split full domain name on subdomain and TLDs
         if (
-            preg_match('/^([\p{L}\d\-]+)\.((?:[\p{L}\-]+\.?)+)$/ui', $this->domain, $matches)
-            || preg_match('/^(xn\-\-[\p{L}\d\-]+)\.(xn\-\-(?:[a-z\d-]+\.?1?)+)$/ui', $this->domain, $matches)
+            preg_match('/^(=?[\p{L}\d\-]+)\.((?:[\p{L}\-]+\.?)+)$/ui', $this->domain, $matches)
+            || preg_match('/^(=?xn\-\-[\p{L}\d\-]+)\.(xn\-\-(?:[a-z\d-]+\.?1?)+)$/ui', $this->domain, $matches)
         ) {
             $this->subDomain = $matches[1];
             $this->TLDs = $matches[2];
@@ -189,7 +189,7 @@ class Whois
         ) {
             $tmp_domain = strtolower($this->subDomain);
             if (
-                preg_match("/^[a-z0-9\-]{3,}$/", $tmp_domain)
+                preg_match("/^=?[a-z0-9\-]{3,}$/", $tmp_domain)
                 && !preg_match("/^-|-$/", $tmp_domain) //&& !preg_match("/--/", $tmp_domain)
             ) {
                 return true;


### PR DESCRIPTION
WHOIS allows lookups in the form of `=domain` to single out domains registered with different registrars (e.g. gmail.com) and return its full lookup info.

Otherwise, simply looking up with `domain` (without the `=`) will yield a notice from WHOIS to specify the search.